### PR TITLE
feat: Implement SAS token and Upload Image API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ next-env.d.ts
 
 # todo
 todo
+bun.lockb

--- a/src/app/api/admin/OTPVerification/route.ts
+++ b/src/app/api/admin/OTPVerification/route.ts
@@ -24,7 +24,6 @@ export async function POST(request: NextRequest, response: NextResponse)
             await db.collection("adminOTPVerification").deleteMany({ adminEmail: adminEmail });
             throw new Error("OTP expired. Please request a new OTP.");
         } else {
-            console.log(otp);
             const hashedOTP = await bcrypt.hash(otp, admin.salt);
             const valid = await bcrypt.compare(hashedOTP, admin.otp);
 

--- a/src/app/api/uploadImage/route.ts
+++ b/src/app/api/uploadImage/route.ts
@@ -16,7 +16,9 @@ async function parseFormData(request: NextRequest): Promise<UploadFilesRequest> 
 
   for (const [key, value] of formData.entries()) {
     if (key === 'files' && typeof value === 'object' && 'arrayBuffer' in value) {
-      const filename = value.name.replaceAll(" ", "_");
+      const timestamp = Date.now();
+      let filename = value.name.replaceAll(" ", "_");
+      filename = `${timestamp}_${filename}`;
       const fileBuffer = Buffer.from(await value.arrayBuffer());
       const fileType = value.type;
       files.push({ filename, fileBuffer, fileType });

--- a/src/app/api/uploadImage/route.ts
+++ b/src/app/api/uploadImage/route.ts
@@ -12,13 +12,10 @@ const containerName = process.env.AZURE_STORAGE_CONTAINER_NAME || 'default-conta
 // Function to parse form data
 async function parseFormData(request: NextRequest): Promise<UploadFilesRequest> {
   const formData = await request.formData();
-  let sasToken = '';
   const files: File[] = [];
 
   for (const [key, value] of formData.entries()) {
-    if (key === 'sasToken') {
-      sasToken = value.toString();
-    } else if (key === 'file' && typeof value === 'object' && 'arrayBuffer' in value) {
+    if (key === 'files' && typeof value === 'object' && 'arrayBuffer' in value) {
       const filename = value.name.replaceAll(" ", "_");
       const fileBuffer = Buffer.from(await value.arrayBuffer());
       const fileType = value.type;
@@ -26,7 +23,7 @@ async function parseFormData(request: NextRequest): Promise<UploadFilesRequest> 
     }
   }
 
-  return { sasToken, files };
+  return { files };
 }
 
 // Function to upload files to Azure Blob Storage

--- a/src/app/api/uploadImage/route.ts
+++ b/src/app/api/uploadImage/route.ts
@@ -1,24 +1,13 @@
 import { NextRequest } from 'next/server';
 import { BlobServiceClient } from '@azure/storage-blob';
 import { Readable } from 'stream';
-import { URLSearchParams } from 'url';
 import { generateResponse } from '../../../utils/response';
 import { UploadFilesRequest, File } from '../../../interfaces/api';
+import { SAS_COOKIE_NAME, isSasTokenExpired } from '../utils';
+import { cookies } from 'next/headers';
 
 const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME || 'default-account-name';
 const containerName = process.env.AZURE_STORAGE_CONTAINER_NAME || 'default-container-name';
-
-// Function to validate SAS token
-async function isSasTokenExpired(sasToken: string): Promise<boolean> {
-  const params = new URLSearchParams(sasToken);
-  const expiryTime = params.get('se');
-  if (!expiryTime) return true;
-
-  const expiryDate = new Date(expiryTime);
-  const currentDate = new Date();
-
-  return currentDate >= expiryDate;
-}
 
 // Function to parse form data
 async function parseFormData(request: NextRequest): Promise<UploadFilesRequest> {
@@ -59,15 +48,19 @@ async function uploadFiles(sasToken: string, files: File[]): Promise<void> {
 // Main POST handler
 export async function POST(request: NextRequest): Promise<Response> {
   try {
-    const { sasToken, files } = await parseFormData(request);
+    const { files } = await parseFormData(request);
+    const sasToken = cookies().get(SAS_COOKIE_NAME);
 
-    if (files.length === 0 || !sasToken)
-      return generateResponse({ error: 'Files or SAS token missing' }, 400);
+    if (!sasToken)
+      return generateResponse({ error: 'SAS token missing' }, 400);
 
-    if (await isSasTokenExpired(sasToken))
+    if (isSasTokenExpired())
       return generateResponse({ error: 'SAS token has expired' }, 400);
 
-    await uploadFiles(sasToken, files);
+    if (files.length === 0)
+      return generateResponse({ error: 'Files missing' }, 400);
+
+    await uploadFiles(sasToken.value, files);
 
     return generateResponse({ message: 'Files uploaded successfully' }, 200);
   } catch (e: any) {

--- a/src/app/api/utils.ts
+++ b/src/app/api/utils.ts
@@ -1,0 +1,19 @@
+import { cookies } from "next/headers";
+
+export const SAS_COOKIE_NAME = 'RCSasToken';
+
+// Function to validate SAS token
+export function isSasTokenExpired(): boolean {
+  const sasTokenCookie = cookies().get(SAS_COOKIE_NAME);
+
+  if (sasTokenCookie === undefined) return true;
+
+  const params = new URLSearchParams(sasTokenCookie.value);
+  const expiryTime = params.get("se");
+  if (!expiryTime) return true;
+
+  const expiryDate = new Date(expiryTime);
+  const currentDate = new Date();
+
+  return currentDate >= expiryDate;
+}

--- a/src/components/EditSlateComponent.tsx
+++ b/src/components/EditSlateComponent.tsx
@@ -110,8 +110,6 @@ function EditSlateSmallerScreen() {
   const slate = useSelectedSlateStore((state) => state.slate);
   const selectedTab = useSelectedTabStore((state) => state.tab);
 
-  console.log(selectedTab);
-
   return slate ? (
     <Box width={"100%"} height={"100%"}>
       <TabPanel tag={"slatePicture"} value={selectedTab as string}>

--- a/src/interfaces/api.ts
+++ b/src/interfaces/api.ts
@@ -5,6 +5,5 @@ export interface File {
 }
 
 export interface UploadFilesRequest {
-  sasToken: string;
   files: File[];
 }

--- a/src/services/sasTokenApi.ts
+++ b/src/services/sasTokenApi.ts
@@ -1,0 +1,11 @@
+import { apiCall } from "@/utils/apiCall";
+
+const sasTokenApiUrl = `api/sasToken`;
+
+export async function checkSasToken() {
+  try {
+    const response = apiCall(sasTokenApiUrl, "GET");
+  } catch (e: any) {
+    throw new Error("getNewSasToken error", e.message);
+  }
+}

--- a/src/services/sasTokenApi.ts
+++ b/src/services/sasTokenApi.ts
@@ -2,6 +2,7 @@ import { apiCall } from "@/utils/apiCall";
 
 const sasTokenApiUrl = `api/sasToken`;
 
+// wrapper function to ask server for a new SAS token
 export async function checkSasToken() {
   try {
     const response = apiCall(sasTokenApiUrl, "GET");

--- a/src/services/uploadSlateApi.ts
+++ b/src/services/uploadSlateApi.ts
@@ -1,0 +1,18 @@
+import { apiCall } from "@/utils/apiCall";
+
+const uploadSlateApiUrl = `api/uploadImage`;
+
+export async function uploadSlatesToBlob(files: File[]) {
+    const formData = new FormData();
+    files.forEach(file => {
+        formData.append("files", file);
+    });
+
+    try {
+        const response = await apiCall(uploadSlateApiUrl, "POST", formData, true);
+        return response;
+    } catch (e: any) {
+        console.log("error uploading slates", e.message);
+        throw new Error("uploadSlatesToBlob error", e.message);
+    }
+}

--- a/src/stores/slateStore.ts
+++ b/src/stores/slateStore.ts
@@ -20,7 +20,6 @@ export const useSelectedSlateStore = create<
       reader.readAsDataURL(slate.file);
       reader.onload = () => {
         const fileURI = reader.result as string;
-        console.log(fileURI);
         set({ slate: { ...slate, base64: fileURI } });
       };
     } else {

--- a/src/utils/apiCall.ts
+++ b/src/utils/apiCall.ts
@@ -1,0 +1,24 @@
+type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+export async function apiCall(url: string, method: HTTPMethod, body?: any) {
+  const options: RequestInit = {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, options);
+
+  if (!response.ok) {
+    // throw the error message that the server sent
+    throw new Error(`API request failed with status ${response.status}, url: ${url}`);
+  }
+
+  return response.json();
+}

--- a/src/utils/apiCall.ts
+++ b/src/utils/apiCall.ts
@@ -1,22 +1,16 @@
 type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
-export async function apiCall(url: string, method: HTTPMethod, body?: any) {
+export async function apiCall(url: string, method: HTTPMethod, body?: any, isFormData?: boolean) {
   const options: RequestInit = {
     method,
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: isFormData ? {} : { 'Content-Type': 'application/json' },
     credentials: 'include',
+    body: isFormData ? body : JSON.stringify(body),
   };
-
-  if (body) {
-    options.body = JSON.stringify(body);
-  }
 
   const response = await fetch(url, options);
 
   if (!response.ok) {
-    // throw the error message that the server sent
     throw new Error(`API request failed with status ${response.status}, url: ${url}`);
   }
 


### PR DESCRIPTION
Implement the SAS token and Upload Image API into frontend.

### Modification

- Change the SAS token API to set SAS token in the browser's cookie, instead of returning it to client
- Change the Upload Image API to read SAS token from browser rather than passing in the token