### PR TITLE
feat(api): Upload image enhancement

### DIFF
--- a/src/app/(authenticated)/(slates)/upload/@hero/page.tsx
+++ b/src/app/(authenticated)/(slates)/upload/@hero/page.tsx
@@ -1,19 +1,19 @@
-"use client";
+'use client';
 
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
-import CheckmarkChip from "@/components/CheckmarkChip";
-import { RoundedButton } from "@/components/RoundedButton";
-import DropdownMenu from "@/components/DropdownMenu";
-import Container from "@mui/material/Container";
-import { useRouter } from "next/navigation";
-import { Fragment } from "react";
-import NavBar from "@/components/mobile/NavBar";
-import { checkSasToken } from "@/services/sasTokenApi";
-import { useFileRowStore } from "@/stores/fileRowStore";
-import { uploadSlatesToBlob } from "@/services/uploadSlateApi";
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import CheckmarkChip from '@/components/CheckmarkChip';
+import { RoundedButton } from '@/components/RoundedButton';
+import DropdownMenu from '@/components/DropdownMenu';
+import Container from '@mui/material/Container';
+import { useRouter } from 'next/navigation';
+import { Fragment } from 'react';
+import NavBar from '@/components/mobile/NavBar';
+import { checkSasToken } from '@/services/sasTokenApi';
+import { useFileRowStore } from '@/stores/fileRowStore';
+import { uploadSlatesToBlob } from '@/services/uploadSlateApi';
 
-const ChipLabels = ["Not blurry", "Bright enough", "Pencil writing is clear"];
+const ChipLabels = ['Not blurry', 'Bright enough', 'Pencil writing is clear'];
 
 /**
  * 1. Remove those row with no values (substrate & fistInverts === null)
@@ -40,10 +40,11 @@ export default function UploadPhotoHeroSection() {
     if (slatesToBeUploaded.length > 0) {
       try {
         await checkSasToken();
-        await uploadSlatesToBlob(slatesToBeUploaded);
+        const uploadResponse = await uploadSlatesToBlob(slatesToBeUploaded);
+        console.log('uploadResponse', uploadResponse);
       } catch (e: any) {
-        console.log("error uploading slates", e.message);
-        throw new Error("uploadSlatesToBlob error", e.message);
+        console.log('error uploading slates', e.message);
+        throw new Error('uploadSlatesToBlob error', e.message);
       }
     }
   };
@@ -63,7 +64,7 @@ export default function UploadPhotoHeroSection() {
         >
           <Box
             justifySelf="end"
-            sx={{ py: 1, display: { xs: "none", md: "block" } }}
+            sx={{ py: 1, display: { xs: 'none', md: 'block' } }}
           >
             <DropdownMenu />
           </Box>
@@ -72,14 +73,14 @@ export default function UploadPhotoHeroSection() {
               <Typography
                 variant="h5"
                 align="center"
-                sx={{ display: { xs: "none", md: "block" } }}
+                sx={{ display: { xs: 'none', md: 'block' } }}
               >
                 Upload your slates photo
               </Typography>
               <Typography
                 variant="h4"
                 align="center"
-                sx={{ fontSize: { xs: "14px", sm: "24px", md: "32px" } }}
+                sx={{ fontSize: { xs: '14px', sm: '24px', md: '32px' } }}
               >
                 Make sure that your photos are:
               </Typography>
@@ -87,8 +88,8 @@ export default function UploadPhotoHeroSection() {
             <Box
               display="flex"
               columnGap={2}
-              flexWrap={"wrap"}
-              justifyContent={"center"}
+              flexWrap={'wrap'}
+              justifyContent={'center'}
               sx={{ rowGap: { xs: 2, md: 0 } }}
             >
               {ChipLabels.map((chipLabel) => (
@@ -99,7 +100,7 @@ export default function UploadPhotoHeroSection() {
           <Box
             display="flex"
             columnGap={2.5}
-            sx={{ display: { xs: "none", md: "flex" } }}
+            sx={{ display: { xs: 'none', md: 'flex' } }}
           >
             <RoundedButton
               variant="contained"
@@ -112,7 +113,7 @@ export default function UploadPhotoHeroSection() {
               itemType="secondary"
               variant="outlined"
               size="large"
-              onClick={() => router.push("/results")}
+              onClick={() => router.push('/results')}
             >
               view results
             </RoundedButton>

--- a/src/app/api/uploadImage/route.ts
+++ b/src/app/api/uploadImage/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { BlobServiceClient } from '@azure/storage-blob';
 import { Readable } from 'stream';
 import { generateResponse } from '../../../utils/response';
-import { UploadFilesRequest, File, UploadFilesResponse } from '../../../interfaces/api';
+import { UploadFilesRequest, File, UploadFilesResponse, UploadFilesReceivedItem } from '../../../interfaces/api';
 import { SAS_COOKIE_NAME, isSasTokenExpired } from '../utils';
 import { cookies } from 'next/headers';
 
@@ -12,41 +12,57 @@ const containerName = process.env.AZURE_STORAGE_CONTAINER_NAME || 'default-conta
 // Function to parse form data
 async function parseFormData(request: NextRequest): Promise<UploadFilesRequest> {
   const formData = await request.formData();
-  const files: File[] = [];
+  const items: UploadFilesReceivedItem[] = [];
 
   for (const [key, value] of formData.entries()) {
-    if (key === 'files' && typeof value === 'object' && 'arrayBuffer' in value) {
+    const match = key.match(/^items\[(\d+)\]\.(id|file)$/);
+    if (!match) continue;
+    const [, index, type] = match;
+    const itemIndex = parseInt(index, 10);
+    
+    // Ensure the item at index is initialized
+    if (!items[itemIndex]) items[itemIndex] = { id: undefined, file: undefined};
+
+    if (type === 'id' && typeof value === 'string') {
+      items[itemIndex].id = value;
+    } else if (type === 'file' && typeof value === 'object' && 'arrayBuffer' in value) {
       const timestamp = Date.now();
       let filename = value.name.replaceAll(" ", "_");
       filename = `${timestamp}_${filename}`;
       const fileBuffer = Buffer.from(await value.arrayBuffer());
       const fileType = value.type;
-      files.push({ filename, fileBuffer, fileType });
+      items[itemIndex].file = { filename, fileBuffer, fileType };
     }
   }
 
-  return { files };
+  return { items };
 }
 
 // Function to upload files to Azure Blob Storage
-async function uploadFiles(sasToken: string, files: File[]): Promise<UploadFilesResponse[]> {
+async function uploadFiles(sasToken: string, items: UploadFilesReceivedItem[]): Promise<UploadFilesResponse[]> {
   const url = `https://${accountName}.blob.core.windows.net/${containerName}?${sasToken}`;
   const blobServiceClient = new BlobServiceClient(url);
   const containerClient = blobServiceClient.getContainerClient(containerName);
 
   let uploadResponses: UploadFilesResponse[] = [];
 
-  for (const { filename, fileBuffer, fileType } of files) {
-    const blockBlobClient = containerClient.getBlockBlobClient(filename);
-    const fileStream = Readable.from(fileBuffer);
+  for (const { id, file } of items) {
+
+    if (!file || !id) {
+      uploadResponses.push({ id: '', filename: '', status: 'failed', error: new Error('File not found') });
+      continue;
+    }
+
+    const blockBlobClient = containerClient.getBlockBlobClient(file.filename);
+    const fileStream = Readable.from(file.fileBuffer);
 
     try {
-      await blockBlobClient.uploadStream(fileStream, fileBuffer.length, 20, {
-        blobHTTPHeaders: { blobContentType: fileType }
+      await blockBlobClient.uploadStream(fileStream, file.fileBuffer.length, 20, {
+        blobHTTPHeaders: { blobContentType: file.fileType }
       });
-      uploadResponses.push({ filename, status: 'success' });
+      uploadResponses.push({ id, filename: file.filename, status: 'success' });
     } catch (error) {
-      uploadResponses.push({ filename, status: 'failed', error: error as Error });
+      uploadResponses.push({ id, filename: file.filename, status: 'failed', error: error as Error });
     }
   }
 
@@ -54,9 +70,9 @@ async function uploadFiles(sasToken: string, files: File[]): Promise<UploadFiles
 }
 
 // Main POST handler
-export async function POST(request: NextRequest): Promise<Response> {
+export async function POST(request: NextRequest) : Promise<Response> {
   try {
-    const { files } = await parseFormData(request);
+    const { items } = await parseFormData(request);
     const sasToken = cookies().get(SAS_COOKIE_NAME);
 
     if (!sasToken)
@@ -65,10 +81,10 @@ export async function POST(request: NextRequest): Promise<Response> {
     if (isSasTokenExpired())
       return generateResponse({ error: 'SAS token has expired' }, 400);
 
-    if (files.length === 0)
-      return generateResponse({ error: 'Files missing' }, 400);
+    if (items.length === 0)
+      return generateResponse({ error: 'No files were uploaded!' }, 400);
 
-    const uploadResults = await uploadFiles(sasToken.value, files);
+    const uploadResults = await uploadFiles(sasToken.value, items);
 
     return generateResponse({
       message: 'Files uploaded successfully',

--- a/src/components/InputFileUpload.tsx
+++ b/src/components/InputFileUpload.tsx
@@ -1,43 +1,43 @@
-"use client";
+'use client';
 
-import { styled } from "@mui/material/styles";
-import Button, { ButtonProps } from "@mui/material/Button";
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
-import Add from "@mui/icons-material/Add";
-import Delete from "@mui/icons-material/Delete";
-import { ChangeEvent } from "react";
-import { SlateState, SlateType } from "@/stores/types";
-import { useFileRowStore } from "@/stores/fileRowStore";
+import { styled } from '@mui/material/styles';
+import Button, { ButtonProps } from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Add from '@mui/icons-material/Add';
+import Delete from '@mui/icons-material/Delete';
+import { ChangeEvent } from 'react';
+import { SlateState, SlateType } from '@/stores/types';
+import { useFileRowStore } from '@/stores/fileRowStore';
 
 const FileActionButton = styled(Button)<ButtonProps>(({ theme }) => ({
-  boxShadow: "none",
-  borderRadius: "8px",
+  boxShadow: 'none',
+  borderRadius: '8px',
   fontWeight: 400,
-  color: "black",
-  textTransform: "capitalize",
-  textAlign: "left",
-  [theme.breakpoints.up("xs")]: {
+  color: 'black',
+  textTransform: 'capitalize',
+  textAlign: 'left',
+  [theme.breakpoints.up('xs')]: {
     width: 160,
-    fontSize: "12px",
-    padding: "8px 10px",
+    fontSize: '12px',
+    padding: '8px 10px',
   },
-  [theme.breakpoints.up("sm")]: {
+  [theme.breakpoints.up('sm')]: {
     width: 200,
-    fontSize: "0.875rem",
-    padding: "4px 24px",
+    fontSize: '0.875rem',
+    padding: '4px 24px',
   },
 }));
 
-const VisuallyHiddenInput = styled("input")({
-  clip: "rect(0 0 0 0)",
-  clipPath: "inset(50%)",
+const VisuallyHiddenInput = styled('input')({
+  clip: 'rect(0 0 0 0)',
+  clipPath: 'inset(50%)',
   height: 1,
-  overflow: "hidden",
-  position: "absolute",
+  overflow: 'hidden',
+  position: 'absolute',
   bottom: 0,
   left: 0,
-  whiteSpace: "nowrap",
+  whiteSpace: 'nowrap',
   width: 1,
 });
 
@@ -46,16 +46,22 @@ interface InputFileUploadProps {
   slate: SlateState;
 }
 
+interface SlateActionButtonProps {
+  slate: SlateState;
+  rowId: string;
+}
+
 const getButtonText = (type: SlateType) => {
-  return type === "substrate"
-    ? "substrate slate"
-    : type === "fishInverts"
-    ? "fish & inverts slate"
-    : "slate";
+  return type === 'substrate'
+    ? 'substrate slate'
+    : type === 'fishInverts'
+      ? 'fish & inverts slate'
+      : 'slate';
 };
 
-export default function InputFileUpload(props: InputFileUploadProps) {
-  const { rowId, slate } = props;
+function SlateActionButton(props: SlateActionButtonProps) {
+  const { slate, rowId } = props;
+
   const setSlateFile = useFileRowStore((state) => state.setSlateFile);
 
   const handleFileChange =
@@ -69,7 +75,42 @@ export default function InputFileUpload(props: InputFileUploadProps) {
     };
 
   return (
-    <Box display="grid" rowGap={1.5} sx={{ width: "100%" }}>
+    <>
+      {slate.file !== null ? (
+        <FileActionButton
+          variant="contained"
+          color="warning"
+          startIcon={<Delete />}
+          onClick={() => setSlateFile(rowId, slate.type, null)}
+        >
+          remove
+        </FileActionButton>
+      ) : (
+        <FileActionButton
+          component="label"
+          role={undefined}
+          variant="contained"
+          tabIndex={-1}
+          startIcon={<Add />}
+          color="secondary"
+        >
+          {getButtonText(slate.type)}
+          <VisuallyHiddenInput
+            type="file"
+            accept="image/*"
+            onChange={handleFileChange(rowId, slate.type)}
+          />
+        </FileActionButton>
+      )}
+    </>
+  );
+}
+
+export default function InputFileUpload(props: InputFileUploadProps) {
+  const { rowId, slate } = props;
+
+  return (
+    <Box display="grid" rowGap={1.5} sx={{ width: '100%' }}>
       <Box
         display="flex"
         alignItems="center"
@@ -77,48 +118,23 @@ export default function InputFileUpload(props: InputFileUploadProps) {
         fontSize="14px"
         padding="18px 20px"
         borderRadius={3}
-        sx={{ backgroundColor: "white" }}
+        sx={{ backgroundColor: 'white' }}
       >
         {/** Desktop view */}
-        {slate.file !== null ? (
-          <FileActionButton
-            variant="contained"
-            color="warning"
-            startIcon={<Delete />}
-            onClick={() => setSlateFile(rowId, slate.type, null)}
-          >
-            remove
-          </FileActionButton>
-        ) : (
-          <FileActionButton
-            component="label"
-            role={undefined}
-            variant="contained"
-            tabIndex={-1}
-            startIcon={<Add />}
-            color="secondary"
-          >
-            {getButtonText(slate.type)}
-            <VisuallyHiddenInput
-              type="file"
-              accept="image/*"
-              onChange={handleFileChange(rowId, slate.type)}
-            />
-          </FileActionButton>
-        )}
+        {slate.status === "not processed" && <SlateActionButton slate={slate} rowId={rowId} />}
         <Typography
           fontSize="14px"
           sx={{
             flex: 1,
             width: {
-              xs: "80px",
+              xs: '80px',
             },
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
           }}
         >
-          {slate.file !== null ? slate.file.name : "Add files here..."}
+          {slate.file !== null ? slate.file.name : 'Add files here...'}
         </Typography>
       </Box>
       <Typography fontSize="14px"></Typography>

--- a/src/components/InputFileUpload.tsx
+++ b/src/components/InputFileUpload.tsx
@@ -7,8 +7,10 @@ import Typography from '@mui/material/Typography';
 import Add from '@mui/icons-material/Add';
 import Delete from '@mui/icons-material/Delete';
 import { ChangeEvent } from 'react';
-import { SlateState, SlateType } from '@/stores/types';
+import { SlateRecognitionStatus, SlateState, SlateType } from '@/stores/types';
 import { useFileRowStore } from '@/stores/fileRowStore';
+import { CircularProgress } from '@mui/material';
+import { DoneRounded, ErrorRounded, HelpRounded } from '@mui/icons-material';
 
 const FileActionButton = styled(Button)<ButtonProps>(({ theme }) => ({
   boxShadow: 'none',
@@ -106,6 +108,25 @@ function SlateActionButton(props: SlateActionButtonProps) {
   );
 }
 
+function ConversionStatusIndicator({
+  status,
+}: {
+  status: SlateRecognitionStatus;
+}) {
+  switch (status) {
+    case 'recognized':
+      return <DoneRounded fontSize="medium" color="primary" />;
+    case 'failed':
+      return <ErrorRounded fontSize="medium" color="error" />;
+    case 'unknown':
+      return <HelpRounded fontSize="medium" color="disabled" />;
+    case 'processing':
+      return <CircularProgress size={20} />;
+    case 'not processed':
+      return <></>;
+  }
+}
+
 export default function InputFileUpload(props: InputFileUploadProps) {
   const { rowId, slate } = props;
 
@@ -121,7 +142,9 @@ export default function InputFileUpload(props: InputFileUploadProps) {
         sx={{ backgroundColor: 'white' }}
       >
         {/** Desktop view */}
-        {slate.status === "not processed" && <SlateActionButton slate={slate} rowId={rowId} />}
+        {slate.status === 'not processed' && (
+          <SlateActionButton slate={slate} rowId={rowId} />
+        )}
         <Typography
           fontSize="14px"
           sx={{
@@ -136,8 +159,13 @@ export default function InputFileUpload(props: InputFileUploadProps) {
         >
           {slate.file !== null ? slate.file.name : 'Add files here...'}
         </Typography>
+        <ConversionStatusIndicator status={slate.status} />
       </Box>
-      <Typography fontSize="14px"></Typography>
+      {slate.status === 'failed' && (
+        <Typography fontSize="14px" color="error" fontWeight={'medium'}>
+          Partial data is extracted as photo failed to meet requirements
+        </Typography>
+      )}
     </Box>
   );
 }

--- a/src/interfaces/api.ts
+++ b/src/interfaces/api.ts
@@ -7,3 +7,9 @@ export interface File {
 export interface UploadFilesRequest {
   files: File[];
 }
+
+export interface UploadFilesResponse {
+  filename: string;
+  status: 'success' | 'failed';
+  error?: Error;
+}

--- a/src/interfaces/api.ts
+++ b/src/interfaces/api.ts
@@ -1,14 +1,22 @@
+import { SlateUploadItem } from "@/stores/types";
+
 export interface File {
   filename: string;
   fileBuffer: Buffer;
   fileType: string;
 }
 
+export interface UploadFilesReceivedItem {
+  id?: string;
+  file?: File;
+}
+
 export interface UploadFilesRequest {
-  files: File[];
+  items: UploadFilesReceivedItem[];
 }
 
 export interface UploadFilesResponse {
+  id: string;
   filename: string;
   status: 'success' | 'failed';
   error?: Error;

--- a/src/services/uploadSlateApi.ts
+++ b/src/services/uploadSlateApi.ts
@@ -1,11 +1,13 @@
+import { SlateUploadItem } from "@/stores/types";
 import { apiCall } from "@/utils/apiCall";
 
 const uploadSlateApiUrl = `api/uploadImage`;
 
-export async function uploadSlatesToBlob(files: File[]) {
+export async function uploadSlatesToBlob(items: SlateUploadItem[]) {
     const formData = new FormData();
-    files.forEach(file => {
-        formData.append("files", file);
+    items.forEach((item, index) => {
+        formData.append(`items[${index}].id`, item.id);
+        formData.append(`items[${index}].file`, item.file);
     });
 
     try {

--- a/src/stores/fileRowStore.ts
+++ b/src/stores/fileRowStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { v4 as uuidv4 } from "uuid";
-import { FileRow, SlateState, SlateType } from "./types";
+import { FileRow, SlateRecognitionStatus, SlateState, SlateType } from "./types";
 
 // All the rows (the main state)
 type FileRowSet = {
@@ -12,6 +12,7 @@ type FileRowActions = {
   addRow: () => void;
   removeRow: (id: string) => void;
   setSlateFile: (id: string, type: SlateType, file: File | null) => void;
+  setSlateStatus: (id: string, type: SlateType, status: SlateRecognitionStatus) => void;
 };
 
 // helper functions
@@ -21,7 +22,7 @@ const createSlate = (type: SlateType): SlateState => {
     type,
     file: null,
     base64: "",
-    status: "unknown",
+    status: "not processed",
   };
 };
 
@@ -57,6 +58,24 @@ export const useFileRowStore = create<FileRowSet & FileRowActions>()((set) => ({
             [type]: {
               ...row[type],
               file: file,
+            },
+          };
+          return updatedRow;
+        }
+        return row;
+      }),
+    })),
+
+  // update slate conversion status
+  setSlateStatus: (id: string, type: SlateType, status: SlateRecognitionStatus) =>
+    set((state) => ({
+      rows: state.rows.map((row) => {
+        if (row.id === id) {
+          const updatedRow = {
+            ...row,
+            [type]: {
+              ...row[type],
+              status: status,
             },
           };
           return updatedRow;

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -6,7 +6,8 @@ export type SlateRecognitionStatus =
   | "recognized"
   | "failed"
   | "unknown"
-  | "processing";
+  | "processing"
+  | "not processed";
 
 export type EmailRole =
   | 'can edit'
@@ -43,4 +44,16 @@ export interface LoggedUser {
   email: string;
   role: UserRole;
   isOTPVerified: boolean;
+}
+
+export interface SlateUploadItem {
+  id: string;
+  file: File;
+}
+
+export interface UploadFilesResponse {
+  id: string;
+  filename: string;
+  status: 'success' | 'failed';
+  error?: Error;
 }


### PR DESCRIPTION
Below are the changes that I made to the upload image API:

1. The upload image API now needs to take in the file and its ID. For example:

```js
// The data does not actually look like this.
// The data will be in the form of FormData.
// But to better visualize it, this is how it looks:
[
  {
    id: "123151-2346123-235",
    file: File // The file object
  },
  {
    id: "123412-151234-12441",
    file: File // The file object
  }
]
```

The backend will use these IDs to inform the client of their upload status (success or fail) after attempting to upload them to blob storage. The ID of the file will be generated on the frontend when the user selects an image to upload.

2. The upload image API will now inform the client about the files that have been uploaded successfully and those that have failed. This is done by returning an array of file IDs along with their status. Below is an example of the response:

```js
[
  {
    id: "123151-2346123-235",
    filename: "nerd-gopher.jpg",
    status: "success"
  },
  {
    id: "123412-151234-12441",
    filename: "kitty.webp",
    status: "failed"
  }
]
```

Upon receiving this response from the backend, the frontend can update the UI to show which files have been uploaded successfully and which have failed. This is not possible previously because the upload image API does not return anything nor inform the client about the upload status of the files. Hopefully these changes make sense to you.